### PR TITLE
Fix Heroku Deploy - Set Node minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Step 0: Make sure you have this sample app deployed. Once you load the root URL,
 
 #### 0. Requirements
 
-- Node 16
+- Node 16.14
 - Postgres database
 
 #### 1. Start API

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "yamljs": "^0.3.0"
       },
       "engines": {
-        "node": "16"
+        "node": "16.14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "16"
+    "node": "16.14"
   },
   "scripts": {
     "start": "nodemon --exec babel-node server/index.js",


### PR DESCRIPTION
When I try to deploy it to Heroku it fails, downgrading the node version to `16.14` fixed the issue for me.

Heroku was trying to use `16.15.1`.